### PR TITLE
Add cql logger

### DIFF
--- a/docs/basics/janusgraph-cfg.md
+++ b/docs/basics/janusgraph-cfg.md
@@ -407,6 +407,18 @@ CQL storage backend options
 | storage.cql.use-external-locking | True to prevent JanusGraph from using its own locking mechanism. Setting this to true eliminates redundant checks when using an external locking mechanism outside of JanusGraph. Be aware that when use-external-locking is set to true, that failure to employ a locking algorithm which locks all columns that participate in a transaction upfront and unlocks them when the transaction ends, will result in a 'read uncommitted' transaction isolation level guarantee. If set to true without an appropriate external locking mechanism in place side effects such as dirty/non-repeatable/phantom reads should be expected. | Boolean | false | MASKABLE |
 | storage.cql.write-consistency-level | The consistency level of write operations against Cassandra | String | QUORUM | MASKABLE |
 
+### storage.cql.query-logger
+CQL query logger options
+
+
+| Name | Description | Datatype | Default Value | Mutability |
+| ---- | ---- | ---- | ---- | ---- |
+| storage.cql.query-logger.constant-threshold | Log only queries which take longer to complete than a configured threshold in milliseconds. Use '-1' to use datastax default value. | Long | -1 | LOCAL |
+| storage.cql.query-logger.enabled | Registers a query logger with datastax cassandra driver | Boolean | false | LOCAL |
+| storage.cql.query-logger.max-logged-parameters | Maximum amount of logged parameters. Queries with a number of parameters higher than this value will not have all their parameters logged. Use '-1' to use datastax default value. | Integer | -1 | LOCAL |
+| storage.cql.query-logger.max-parameter-value-length | Parameter values longer than this value will be truncated when logged. Use '-1' to use datastax default value. | Integer | -1 | LOCAL |
+| storage.cql.query-logger.max-query-string-length | Max query string length to be logged when query logger is enabled. Use '-1' to use datastax default value. | Integer | -1 | LOCAL |
+
 ### storage.cql.ssl
 Configuration options for SSL
 

--- a/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/time/TimestampProviders.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/diskstorage/util/time/TimestampProviders.java
@@ -70,7 +70,7 @@ public enum TimestampProviders implements TimestampProvider {
     MICRO {
         @Override
         public Instant getTime() {
-            return Instant.now();
+            return Instant.now().truncatedTo(getUnit());
         }
 
         @Override
@@ -93,7 +93,7 @@ public enum TimestampProviders implements TimestampProvider {
     MILLI {
         @Override
         public Instant getTime() {
-            return Instant.now();
+            return Instant.now().truncatedTo(getUnit());
         }
 
         @Override

--- a/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
+++ b/janusgraph-cql/src/main/java/org/janusgraph/diskstorage/cql/CQLConfigOptions.java
@@ -285,4 +285,44 @@ public interface CQLConfigOptions {
             ConfigOption.Type.MASKABLE,
             String.class);
 
+    // Query logger
+    ConfigNamespace QUERY_LOGGER = new ConfigNamespace(
+        CQL_NS,
+        "query-logger",
+        "CQL query logger options");
+
+    ConfigOption<Boolean> QUERY_LOGGER_ENABLED = new ConfigOption<>(
+        QUERY_LOGGER,
+        "enabled",
+        "Registers a query logger with datastax cassandra driver",
+        ConfigOption.Type.LOCAL,
+        false);
+
+    ConfigOption<Integer> QUERY_LOGGER_MAX_QUERY_STRING_LENGTH = new ConfigOption<>(
+        QUERY_LOGGER,
+        "max-query-string-length",
+        "Max query string length to be logged when query logger is enabled. Use '-1' to use datastax default value.",
+        ConfigOption.Type.LOCAL,
+        -1);
+
+    ConfigOption<Long> QUERY_LOGGER_CONSTANT_THRESHOLD = new ConfigOption<>(
+        QUERY_LOGGER,
+        "constant-threshold",
+        "Log only queries which take longer to complete than a configured threshold in milliseconds. Use '-1' to use datastax default value.",
+        ConfigOption.Type.LOCAL,
+        -1L);
+
+    ConfigOption<Integer> QUERY_LOGGER_MAX_LOGGED_PARAMETERS = new ConfigOption<>(
+        QUERY_LOGGER,
+        "max-logged-parameters",
+        "Maximum amount of logged parameters. Queries with a number of parameters higher than this value will not have all their parameters logged. Use '-1' to use datastax default value.",
+        ConfigOption.Type.LOCAL,
+        -1);
+
+    ConfigOption<Integer> QUERY_LOGGER_MAX_PARAMETER_VALUE_LENGTH = new ConfigOption<>(
+        QUERY_LOGGER,
+        "max-parameter-value-length",
+        "Parameter values longer than this value will be truncated when logged. Use '-1' to use datastax default value.",
+        ConfigOption.Type.LOCAL,
+        -1);
 }


### PR DESCRIPTION
This PR adds possibility to enable CQL driver queries logging in DEBUG mode. By default it is disabled. To enable it, use `storage.cql.query-logger.enabled=true` parameter. Properties example:
```
storage.cql.query-logger.enabled=true
storage.cql.query-logger.constant-threshold=1
storage.cql.query-logger.max-query-string-length=1000000
```

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
- [ ] If this PR is a documentation-only change, have you added a `[doc only]`
  tag to the first line of your commit message to avoid spending CPU cycles in
  Travis CI when no code, tests, or build configuration are modified?

### Note:
Please ensure that once the PR is submitted, you check Travis CI for build issues and submit an update to your PR as soon as possible.

